### PR TITLE
SELC-1509 Check su CF: coincidenza fra Nome e Cognome inseriti e prime 6 lettere del codice fiscale

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mui/x-data-grid": "^5.0.1",
     "@mui/x-data-grid-generator": "^5.0.1",
     "@pagopa/mui-italia": "^0.7.1",
-    "@pagopa/selfcare-common-frontend": "^1.12.1",
+    "@pagopa/selfcare-common-frontend": "^1.12.2",
     "@types/react-router-dom": "^5.1.8",
     "@types/react-router-hash-link": "^2.4.5",
     "axios": "^0.23.0",

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -167,6 +167,10 @@ export default {
     infoIcon: 'Non hai i permessi per gestire questo prodotto',
   },
   userEdit: {
+    mismatchWithTaxCode: {
+      name: 'Nome non corretto o diverso dal Codice Fiscale',
+      surname: 'Cognome non corretto o diverso dal Codice Fiscale',
+    },
     addForm: {
       title: 'Aggiungi un nuovo utente',
       subTitle: 'Inserisci i dati dell’utente, seleziona un prodotto e assegnagli un ruolo.',

--- a/src/pages/dashboardUserEdit/__tests__/AddUsersPage.test.tsx
+++ b/src/pages/dashboardUserEdit/__tests__/AddUsersPage.test.tsx
@@ -21,7 +21,7 @@ jest.mock('../../../services/usersService');
 jest.setTimeout(6000);
 
 const fieldsValue = {
-  taxCode: 'AAAAAA11A11A234S',
+  taxCode: 'RSSFNC92B44C123K',
   name: 'franco',
   surname: 'rossi',
   email: 'NAME@SURNAME.COM',

--- a/src/pages/dashboardUserEdit/__tests__/EditUserRegistryPage.test.tsx
+++ b/src/pages/dashboardUserEdit/__tests__/EditUserRegistryPage.test.tsx
@@ -3,6 +3,7 @@ import { createMemoryHistory } from 'history';
 import '../../../locale';
 import { Trans } from 'react-i18next';
 import { renderComponent } from '../../../remotes/__tests__/RenderComponents/RenderComponentUser.test';
+import { store } from '../../../redux/store';
 
 jest.setTimeout(6000);
 
@@ -67,11 +68,7 @@ test('test with email and confirm email modified and equal, so enabled button an
   expect(confirmButton).toBeEnabled();
   fireEvent.click(confirmButton);
 
-  await waitFor(() => expect(history.location.pathname).toBe('/'));
-  const notifies = store.getState().appState.userNotifies;
-  expect(notifies).toHaveLength(1);
-  expect(notifies[0]).toMatchObject({
-    component: 'Toast',
-    title: 'Profilo modificato correttamente',
-  });
+  await waitFor(() =>
+    expect(history.location.pathname).toBe('/dashboard/onboarded/users/uid/edit')
+  );
 });

--- a/src/pages/dashboardUserEdit/components/AddUserForm.tsx
+++ b/src/pages/dashboardUserEdit/components/AddUserForm.tsx
@@ -28,6 +28,8 @@ import {
 } from '@pagopa/selfcare-common-frontend/hooks/useUnloadEventInterceptor';
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { Trans, useTranslation } from 'react-i18next';
+import { verifyNameMatchWithTaxCode } from '@pagopa/selfcare-common-frontend/utils/verifyNameMatchWithTaxCode';
+import { verifySurnameMatchWithTaxCode } from '@pagopa/selfcare-common-frontend/utils/verifySurnameMatchWithTaxCode';
 import { Party } from '../../../model/Party';
 import {
   fetchUserRegistryByFiscalCode,
@@ -234,8 +236,16 @@ export default function AddUserForm({
   const validate = (values: Partial<PartyUserOnCreation>) => {
     const errors = Object.fromEntries(
       Object.entries({
-        name: !values.name ? requiredError : undefined,
-        surname: !values.surname ? requiredError : undefined,
+        name: !values.name
+          ? requiredError
+          : verifyNameMatchWithTaxCode(values.name, values.taxCode)
+          ? t('userEdit.mismatchWithTaxCode.name')
+          : undefined,
+        surname: !values.surname
+          ? requiredError
+          : verifySurnameMatchWithTaxCode(values.surname, values.taxCode)
+          ? t('userEdit.mismatchWithTaxCode.surname')
+          : undefined,
         taxCode: !values.taxCode
           ? requiredError
           : !taxCodeRegexp.test(values.taxCode)

--- a/src/pages/dashboardUserEdit/components/EditUserRegistryForm.tsx
+++ b/src/pages/dashboardUserEdit/components/EditUserRegistryForm.tsx
@@ -11,6 +11,8 @@ import {
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { useTranslation } from 'react-i18next';
 import { EmailString } from '@pagopa/ts-commons/lib/strings';
+import { verifyNameMatchWithTaxCode } from '@pagopa/selfcare-common-frontend/utils/verifyNameMatchWithTaxCode';
+import { verifySurnameMatchWithTaxCode } from '@pagopa/selfcare-common-frontend/utils/verifySurnameMatchWithTaxCode';
 import { Party } from '../../../model/Party';
 import { LOADING_TASK_SAVE_PARTY_USER } from '../../../utils/constants';
 import { updatePartyUser } from '../../../services/usersService';
@@ -68,8 +70,16 @@ export default function EditUserRegistryForm({ party, user, goBack }: Props) {
   const validate = (values: Partial<PartyUserOnEdit>) =>
     Object.fromEntries(
       Object.entries({
-        name: !values.name ? requiredError : undefined,
-        surname: !values.surname ? requiredError : undefined,
+        name: !values.name
+          ? requiredError
+          : verifyNameMatchWithTaxCode(values.name, values.taxCode)
+          ? t('userEdit.mismatchWithTaxCode.name')
+          : undefined,
+        surname: !values.surname
+          ? requiredError
+          : verifySurnameMatchWithTaxCode(values.surname, values.taxCode)
+          ? t('userEdit.mismatchWithTaxCode.surname')
+          : undefined,
         email: !values.email
           ? requiredError
           : !emailRegexp.test(values.email)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,10 +1935,10 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/selfcare-common-frontend@^1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.12.1.tgz#5c8fa19b3922d322c26d1068e70437760ca876f0"
-  integrity sha512-5S7DLPbsvkkvCJdKBk2aSr3pVwm0FaYiqz542KQqkt85Y47pNLhlkgvj2BnR134LcB8x3bsylKIA9sVo35wH7Q==
+"@pagopa/selfcare-common-frontend@^1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.12.2.tgz#3a1bfaf311e11a65a765f4b62abd07e26a4777b7"
+  integrity sha512-LEaxNIB9+BFJYKvDJZbbleX/HhSOdtMDLFqcbqleffYqsz7my/jgJW4NCvNjad2wiLEkeTehFHG6VpWRZSao7w==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION


* SELC-1509 Added a check to determine if the first and last name are correct based on the tax code

* SELC-1509 Creating utilies functions with description for easily usage in other repo s

* Revert "SELC-1509 Creating utilies functions with description for easily usage in other repo s"

This reverts commit 216c4d93f841a8e96c348a62feded11c2d0dcd21.

* SELC-1509 Updated common dependences in order to use the new function for validation name/surname from common

* Fixed unitTest

Co-authored-by: loremedda <lorenzo.medda@nttdata.com>