### PR TITLE
PNPG-178 Fixed role assignment error on PNPG when multiple environment products are present in addition to the real product

### DIFF
--- a/src/pages/dashboardUserEdit/AddProductToUserPage.tsx
+++ b/src/pages/dashboardUserEdit/AddProductToUserPage.tsx
@@ -61,8 +61,6 @@ function AddProductToUserPage({ party, activeProducts, productsRolesMap, partyUs
     },
   ];
 
-  const prodPnpg = activeProducts.find((p) => p.id === 'prod-pn-pg');
-
   return (
     <Grid
       container
@@ -217,7 +215,6 @@ function AddProductToUserPage({ party, activeProducts, productsRolesMap, partyUs
               } as PartyUserOnCreation
             }
             canEditRegistryData={false}
-            selectedProduct={prodPnpg ?? undefined}
           />
         </Grid>
       </Grid>

--- a/src/pages/dashboardUserEdit/components/AddUserForm.tsx
+++ b/src/pages/dashboardUserEdit/components/AddUserForm.tsx
@@ -135,6 +135,7 @@ export default function AddUserForm({
   const isPnpg = !!products.find((p) => p.id === 'prod-pn-pg');
   const isPnpgTheOnlyProduct =
     !!products.find((p) => p.id === 'prod-pn-pg') && products.length === 1;
+  const pnpgProduct = products.find((p) => p.id === 'prod-pn-pg');
 
   useEffect(() => {
     if (!initialFormData.taxCode) {
@@ -170,6 +171,12 @@ export default function AddUserForm({
   useEffect(() => {
     setUserProduct(selectedProduct);
   }, [selectedProduct]);
+
+  useEffect(() => {
+    if (isPnpgTheOnlyProduct && initialFormData.taxCode === '') {
+      setUserProduct(pnpgProduct);
+    }
+  }, []);
 
   const goBackInner =
     goBack ??

--- a/src/services/__mocks__/usersService.ts
+++ b/src/services/__mocks__/usersService.ts
@@ -759,6 +759,42 @@ export const mockedUsers: Array<PartyUserDetail> = [
     ],
     isCurrentUser: false,
   },
+  {
+    id: 'uid63',
+    taxCode: 'DNNGRL83A01C352D',
+    name: 'Gabriele',
+    surname: 'Rossi',
+    email: 'mock@mockpec.com',
+    userRole: 'ADMIN',
+    status: 'ACTIVE',
+    products: [
+      {
+        id: 'prod-pn-pg',
+        title: 'Piattaforma Notifiche Persone Giuridiche',
+        roles: [
+          {
+            relationshipId: 'd83a7eb3-bbb8-4b18-8230-ed74740b4c29',
+            role: 'pg-operator',
+            status: 'ACTIVE',
+            selcRole: 'LIMITED',
+          },
+        ],
+      },
+      {
+        id: 'prod-pn-pg-uat',
+        title: 'PNPG UAT',
+        roles: [
+          {
+            relationshipId: '14be375d-f82e-446b-b7f8-5c2a271315ea',
+            role: 'pg-admin',
+            status: 'ACTIVE',
+            selcRole: 'ADMIN',
+          },
+        ],
+      },
+    ],
+    isCurrentUser: false,
+  },
 ];
 
 type PartyGroupMock = PartyGroup & {


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Removed the selectedProduct from the AddUserForm component so that the product is not forced even if there are environmental products, then added a "self-selection" dictated by a condition which covers all cases (both with the real product only, both when environment products are also present)
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The forcing of the product done immediately, did not allow to add roles on other products if present and if the display condition was respected, thus creating the bug

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- Adding a user with only the real product = self-selected product
- Addition of user also with ambient products = it is possible to select the product
- Added role when environmental products are also present = assuming the conditions are met and therefore displaying the add role button, it is possible to select the product of interest
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.