### PR TITLE
PNPG-199 Set a fixed size to buttons in addUserForm to prevent them from taking up their full size

### DIFF
--- a/src/pages/dashboardUserEdit/components/AddUserForm.tsx
+++ b/src/pages/dashboardUserEdit/components/AddUserForm.tsx
@@ -706,39 +706,24 @@ export default function AddUserForm({
           )}
         </Grid>
 
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          mt={5}
-          sx={{
-            [theme.breakpoints.down('lg')]: {
-              flexDirection: 'column',
-            },
-          }}
-        >
-          <Stack display="flex" justifyContent="flex-start">
-            <Button color="primary" variant="outlined" onClick={() => onExit(goBackInner)}>
-              {t('userEdit.addForm.backButton')}
-            </Button>
-          </Stack>
-          <Stack
-            display="flex"
-            justifyContent="flex-end"
-            sx={{
-              [theme.breakpoints.down('lg')]: {
-                marginTop: 2,
-              },
-            }}
+        <Stack direction="row" display="flex" justifyContent="space-between" mt={5}>
+          <Button
+            color="primary"
+            variant="outlined"
+            size="medium"
+            onClick={() => onExit(goBackInner)}
           >
-            <Button
-              disabled={!formik.dirty || !formik.isValid}
-              color="primary"
-              variant="contained"
-              type="submit"
-            >
-              {t('userEdit.addForm.continueButton')}
-            </Button>
-          </Stack>
+            {t('userEdit.addForm.backButton')}
+          </Button>
+          <Button
+            disabled={!formik.dirty || !formik.isValid}
+            color="primary"
+            variant="contained"
+            type="submit"
+            size="medium"
+          >
+            {t('userEdit.addForm.continueButton')}
+          </Button>
         </Stack>
       </form>
     </React.Fragment>


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Set the prop size to medium in the buttons present in the add user form


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Set prop size of buttons on add user form to medium to prevent them from expanding to full width when browser size changes

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
By shrinking the browser window, the buttons will remain with the same width
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.