### PR TITLE
Propagation of i18n for correctly change language also from the orchestrator + fixed translate key typo

### DIFF
--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -17,6 +17,10 @@ export default {
         email: 'E-Mail-Adresse',
         role: 'Rolle',
       },
+      rows: {
+        isCurrentUser: '(du)',
+        suspendedChip: 'Ausgesetzt',
+      },
     },
     filterRole: {
       placeholder: 'Alle Rollen',

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -17,6 +17,10 @@ export default {
         email: 'Email',
         role: 'Role',
       },
+      rows: {
+        isCurrentUser: '(you)',
+        suspendedChip: 'Suspended',
+      },
     },
     filterRole: {
       placeholder: 'All roles',

--- a/src/locale/fr.ts
+++ b/src/locale/fr.ts
@@ -17,6 +17,10 @@ export default {
         email: 'E-mail',
         role: 'Fonction',
       },
+      rows: {
+        isCurrentUser: '(toi)',
+        suspendedChip: 'Suspendue',
+      },
     },
     filterRole: {
       placeholder: 'Toutes les fonctions',

--- a/src/locale/locale-utils.ts
+++ b/src/locale/locale-utils.ts
@@ -1,6 +1,14 @@
 import { i18n } from 'i18next';
 import it from './it';
+import en from './en';
+import fr from './fr';
+import de from './de';
+import sl from './sl';
 
 export const configureI18n = (i18n: i18n) => {
   i18n.addResourceBundle('it', 'translation', it, true);
+  i18n.addResourceBundle('en', 'translation', en, true);
+  i18n.addResourceBundle('fr', 'translation', fr, true);
+  i18n.addResourceBundle('de', 'translation', de, true);
+  i18n.addResourceBundle('sl', 'translation', sl, true);
 };

--- a/src/locale/sl.ts
+++ b/src/locale/sl.ts
@@ -17,6 +17,10 @@ export default {
         email: 'E-pošta',
         role: 'Vloga',
       },
+      rows: {
+        isCurrentUser: '(ti)',
+        suspendedChip: 'Odstavljen',
+      },
     },
     filterRole: {
       placeholder: 'Vse vloge',

--- a/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
+++ b/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
@@ -3,7 +3,7 @@ import TitleBox from '@pagopa/selfcare-common-frontend/components/TitleBox';
 import { useEffect, useMemo, useState } from 'react';
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/utils/routes-utils';
-import { useTranslation, Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useUnloadEventOnExit } from '@pagopa/selfcare-common-frontend/hooks/useUnloadEventInterceptor';
 import { ButtonNaked } from '@pagopa/mui-italia';
@@ -128,12 +128,7 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Pro
               subTitle={
                 !isPnpg
                   ? t('usersPage.generic.subTitle')
-                  : ((
-                      <Trans i18next="usersPage.pnpg.subTitle">
-                        Gestisci gli utenti che possono leggere le notifiche di{' '}
-                        {{ businessName: party.description }}.
-                      </Trans>
-                    ) as unknown as string)
+                  : t('usersPage.pnpg.subTitle', { businessName: party.description })
               }
               mbTitle={2}
             />


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Propagation of i18n for correctly change language also from the orchestrator + fixed little typo

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The translations only worked locally when accessing the microFE, as the i18n object was not propagated, thus resulting in the fact that when accessing it from the orchestrator, the strings were not translated.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.