### PR TITLE
[SELC-5233] Fix: Disable removal of admin users for prod interop 

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -180,6 +180,8 @@ export default {
     role: 'Ruolo',
     statusLabel: 'Sospeso',
     infoIcon: 'Non hai i permessi per gestire questo prodotto',
+    removeRoleBannerText:
+      'Per rimuovere un Amministratore, segui le indicazioni che trovi in <1>questa pagina</1>.',
   },
   userEdit: {
     mismatchWithTaxCode: {
@@ -214,7 +216,7 @@ export default {
         title: 'Seleziona il ruolo che vuoi assegnare all’utente',
       },
       bannerText:
-        'Per aggiungere un Amministratore, segui le indicazioni che trovi <1>in questa pagina</1>.',
+        'Per aggiungere un Amministratore, segui le indicazioni che trovi in <1>questa pagina</1>.',
       backButton: 'Indietro',
       continueButton: 'Continua',
       errors: {

--- a/src/pages/dashboardUserDetail/components/UserProductActions.tsx
+++ b/src/pages/dashboardUserDetail/components/UserProductActions.tsx
@@ -3,7 +3,6 @@ import useErrorDispatcher from '@pagopa/selfcare-common-frontend/lib/hooks/useEr
 import useLoading from '@pagopa/selfcare-common-frontend/lib/hooks/useLoading';
 import useUserNotify from '@pagopa/selfcare-common-frontend/lib/hooks/useUserNotify';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/lib/utils/routes-utils';
-import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { Party, UserStatus } from '../../../model/Party';

--- a/src/pages/dashboardUserDetail/components/UserProductActions.tsx
+++ b/src/pages/dashboardUserDetail/components/UserProductActions.tsx
@@ -1,12 +1,13 @@
-import { Link, Typography, Box } from '@mui/material';
+import { Box, Link, Typography } from '@mui/material';
 import useErrorDispatcher from '@pagopa/selfcare-common-frontend/lib/hooks/useErrorDispatcher';
 import useLoading from '@pagopa/selfcare-common-frontend/lib/hooks/useLoading';
 import useUserNotify from '@pagopa/selfcare-common-frontend/lib/hooks/useUserNotify';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/lib/utils/routes-utils';
+import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { Party, UserStatus } from '../../../model/Party';
-import { PartyUserDetail, PartyUserProductRole, PartyUserProduct } from '../../../model/PartyUser';
+import { PartyUserDetail, PartyUserProduct, PartyUserProductRole } from '../../../model/PartyUser';
 import { ProductRolesLists, transcodeProductRole2Title } from '../../../model/ProductRole';
 import { updatePartyUserStatus } from '../../../services/usersService';
 import { LOADING_TASK_UPDATE_PARTY_USER_STATUS } from '../../../utils/constants';
@@ -260,19 +261,22 @@ export default function UserProductActions({
       onConfirm: confirmChangeStatus,
     });
   };
+
   return (
     <>
       {showActions && !user.isCurrentUser && canEdit && (
         <Box display="flex" justifyContent="flex-end">
-          {(moreRolesOnProduct || !isProductDetailPage) && !user.isCurrentUser && (
-            <Box mr={3} width="52px" display="flex" justifyContent="flex-end">
-              <Link onClick={handleDelete} component="button" sx={{ textDecoration: 'none' }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold', color: 'error.main' }}>
+          {(moreRolesOnProduct || !isProductDetailPage) &&
+            !user.isCurrentUser &&
+            !(product.id === 'prod-interop' && role.selcRole === 'ADMIN') && (
+              <Box mr={3} width="52px" display="flex" justifyContent="flex-end">
+                <Link onClick={handleDelete} component="button" sx={{ textDecoration: 'none' }}>
+                  <Typography variant="caption" sx={{ fontWeight: 'bold', color: 'error.main' }}>
                   {t('userDetail.actions.deleteButton')}
-                </Typography>
-              </Link>
-            </Box>
-          )}
+                  </Typography>
+                </Link>
+              </Box>
+            )}
           {!isPnpg && (
             <Box width="52px" display="flex">
               <Link

--- a/src/pages/dashboardUserDetail/userDetailPage/components/UserProductDetail.tsx
+++ b/src/pages/dashboardUserDetail/userDetailPage/components/UserProductDetail.tsx
@@ -116,27 +116,29 @@ export default function UserProductDetail({
       <Grid item xs={12} mt={3}>
         <Divider sx={{ borderColor: 'background.default' }} />
       </Grid>
-      {userProduct.id === 'prod-interop' && userProduct.roles[0].selcRole === 'ADMIN' && (
-        <Alert severity="info" sx={{ mt: 2 }}>
-          <Trans
-            i18nKey="userEdit.addForm.bannerText"
-            components={{
-              1: (
-                <Link
-                  href="https://docs.pagopa.it/interoperabilita-1/manuale-operativo/guida-alladesione#aggiungere-o-rimuovere-un-operatore-amministrativo-a-pdnd-interoperabilita"
-                  color={'text.primary'}
-                  sx={{ textDecorationColor: 'text.primary' }}
-                  target="_blank"
-                />
-              ),
-            }}
-          >
-            {
-              'Per aggiungere un Amministratore, segui le indicazioni che trovi in <1>questa pagina</1>.'
-            }
-          </Trans>
-        </Alert>
-      )}
+      {userProduct.id === 'prod-interop' &&
+        userProduct.roles[0].selcRole === 'ADMIN' &&
+        !partyUser.isCurrentUser && (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            <Trans
+              i18nKey="userDetail.removeRoleBannerText"
+              components={{
+                1: (
+                  <Link
+                    href="https://docs.pagopa.it/interoperabilita-1/manuale-operativo/guida-alladesione#aggiungere-o-rimuovere-un-operatore-amministrativo-a-pdnd-interoperabilita"
+                    color={'text.primary'}
+                    sx={{ textDecorationColor: 'text.primary' }}
+                    target="_blank"
+                  />
+                ),
+              }}
+            >
+              {
+                'Per rimuovere un Amministratore, segui le indicazioni che trovi in <1>questa pagina</1>.'
+              }
+            </Trans>
+          </Alert>
+        )}
       <Grid item xs={12}>
         <UserProductRoles
           showActions={!showActionOnProduct}

--- a/src/pages/dashboardUserDetail/userDetailPage/components/UserProductDetail.tsx
+++ b/src/pages/dashboardUserDetail/userDetailPage/components/UserProductDetail.tsx
@@ -1,12 +1,12 @@
-import { Grid, Typography, Chip, Box, Divider, Tooltip } from '@mui/material';
-import { useTranslation } from 'react-i18next';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { Alert, Box, Chip, Divider, Grid, Link, Tooltip, Typography } from '@mui/material';
 import { ProductAvatar } from '@pagopa/mui-italia';
+import { Trans, useTranslation } from 'react-i18next';
 import { Party } from '../../../../model/Party';
-import { Product } from '../../../../model/Product';
 import { PartyUserDetail, PartyUserProduct } from '../../../../model/PartyUser';
-import UserProductRoles from '../../components/UserProductRoles';
+import { Product } from '../../../../model/Product';
 import { ProductRolesLists } from '../../../../model/ProductRole';
+import UserProductRoles from '../../components/UserProductRoles';
 import UserProductActions from './../../components/UserProductActions';
 import UserProductGroups from './../../components/UserProductGroups';
 
@@ -72,7 +72,7 @@ export default function UserProductDetail({
                   <Chip
                     label={t('userDetail.statusLabel')}
                     aria-label={'Suspended'}
-                    color='warning'
+                    color="warning"
                     sx={{
                       fontSize: '14px',
                       borderRadius: '16px',
@@ -116,6 +116,27 @@ export default function UserProductDetail({
       <Grid item xs={12} mt={3}>
         <Divider sx={{ borderColor: 'background.default' }} />
       </Grid>
+      {userProduct.id === 'prod-interop' && userProduct.roles[0].selcRole === 'ADMIN' && (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          <Trans
+            i18nKey="userEdit.addForm.bannerText"
+            components={{
+              1: (
+                <Link
+                  href="https://docs.pagopa.it/interoperabilita-1/manuale-operativo/guida-alladesione#aggiungere-o-rimuovere-un-operatore-amministrativo-a-pdnd-interoperabilita"
+                  color={'text.primary'}
+                  sx={{ textDecorationColor: 'text.primary' }}
+                  target="_blank"
+                />
+              ),
+            }}
+          >
+            {
+              'Per aggiungere un Amministratore, segui le indicazioni che trovi in <1>questa pagina</1>.'
+            }
+          </Trans>
+        </Alert>
+      )}
       <Grid item xs={12}>
         <UserProductRoles
           showActions={!showActionOnProduct}

--- a/src/pages/dashboardUserEdit/components/AddUserForm.tsx
+++ b/src/pages/dashboardUserEdit/components/AddUserForm.tsx
@@ -662,7 +662,7 @@ export default function AddUserForm({
                 }}
               >
                 {
-                  'Per aggiungere un Amministratore, segui le indicazioni che trovi <1>in questa pagina</1>.'
+                  'Per aggiungere un Amministratore, segui le indicazioni che trovi in <1>questa pagina</1>.'
                 }
               </Trans>
             </Alert>

--- a/src/services/__mocks__/usersService.ts
+++ b/src/services/__mocks__/usersService.ts
@@ -203,8 +203,8 @@ export const mockedUsers: Array<PartyUserDetail> = [
         roles: [
           {
             relationshipId: 'rel4',
-            role: 'referente-tecnico',
-            selcRole: 'LIMITED',
+            role: 'amministratore',
+            selcRole: 'ADMIN',
             status: 'ACTIVE',
           },
           {
@@ -554,7 +554,7 @@ export const mockedUsers: Array<PartyUserDetail> = [
         roles: [
           {
             relationshipId: 'rel16',
-            role: 'referente-tecnico',
+            role: 'test',
             selcRole: 'LIMITED',
             status: 'ACTIVE',
           },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Hidden the remove button for prod interop in the production enviroment
Added banner to inform the user how to remove admins for prod-interop
<!--- Describe your changes in detail -->

#### Motivation and Context
Removing admin users is not avaible at the moment for prod interop
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in dev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.