### PR TITLE
[SELC-5832] Feat: Aggregator onboarded on only pagoPa cannot add new users

### DIFF
--- a/src/microcomponents/mock_dashboard/data/party.ts
+++ b/src/microcomponents/mock_dashboard/data/party.ts
@@ -96,7 +96,7 @@ export const mockedParties: Array<Party> = [
           recipientCode: 'FLGKROWP',
           publicServices: true,
         },
-        userProductActions: [Actions.ListProductUsers, Actions.ManageProductUsers],
+        userProductActions: [Actions.ListProductUsers],
       },
       {
         productId: 'prod-pn',
@@ -291,7 +291,6 @@ export const mockedParties: Array<Party> = [
         userProductActions: [
           Actions.ListProductUsers,
           Actions.AccessProductBackoffice,
-          Actions.ManageProductUsers,
           Actions.ManageProductUsers,
           Actions.ViewDelegations,
           Actions.ListActiveProducts,

--- a/src/pages/dashboardUserEdit/AddLegalRepresentativeForm.tsx
+++ b/src/pages/dashboardUserEdit/AddLegalRepresentativeForm.tsx
@@ -7,7 +7,6 @@ import {
   useErrorDispatcher,
   useLoading,
 } from '@pagopa/selfcare-common-frontend/lib';
-import { trackEvent } from '@pagopa/selfcare-common-frontend/lib/services/analyticsService';
 import { emailRegexp } from '@pagopa/selfcare-common-frontend/lib/utils/constants';
 import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import { verifyChecksumMatchWithTaxCode } from '@pagopa/selfcare-common-frontend/lib/utils/verifyChecksumMatchWithTaxCode';
@@ -253,15 +252,7 @@ export default function AddLegalRepresentativeForm({
               formik.setFieldError(param.name, renderErrorMessage(param.name));
             });
           }
-          trackEvent(`ONBOARDING_ADD_MANAGER_CONFLICT_ERROR`, {
-            party_id: party?.partyId,
-            reason: error?.detail,
-          });
         } else {
-          trackEvent(`ONBOARDING_ADD_MANAGER_GENERIC_ERROR`, {
-            party_id: party?.partyId,
-            reason: error?.detail,
-          });
           addError({
             id: `VALIDATE_USER_ERROR`,
             blocking: false,

--- a/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
+++ b/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
@@ -63,6 +63,7 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
   const isMobile = useIsMobile('md');
 
   const canSeeUsers = getAllProductsWithPermission(Actions.ListActiveProducts).length > 0;
+  const canAddUser = getAllProductsWithPermission(Actions.ManageProductUsers).length > 0;
 
   const addUserUrl = resolvePathVariables(
     DASHBOARD_USERS_ROUTES.PARTY_USERS.subRoutes.ADD_PARTY_USER.path,
@@ -152,25 +153,27 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
               mbTitle={2}
             />
           </Grid>
-          <Grid
-            item
-            xs={12}
-            md={3}
-            flexDirection={isMobile ? 'row-reverse' : 'row'}
-            mt={isMobile ? 3 : 5}
-            display="flex"
-            justifyContent="flex-end"
-          >
-            <Stack>
-              <Button
-                variant="contained"
-                sx={{ height: '48px', width: '163px' }}
-                onClick={() => onExit(() => history.push(addUserUrl))}
-              >
-                {t('usersTable.addButton')}
-              </Button>
-            </Stack>
-          </Grid>
+          {canAddUser && (
+            <Grid
+              item
+              xs={12}
+              md={3}
+              flexDirection={isMobile ? 'row-reverse' : 'row'}
+              mt={isMobile ? 3 : 5}
+              display="flex"
+              justifyContent="flex-end"
+            >
+              <Stack>
+                <Button
+                  variant="contained"
+                  sx={{ height: '48px', width: '163px' }}
+                  onClick={() => onExit(() => history.push(addUserUrl))}
+                >
+                  {t('usersTable.addButton')}
+                </Button>
+              </Stack>
+            </Grid>
+          )}
         </Grid>
         <Grid item xs={12}>
           <CustomAlert sx={{ mt: 5 }} />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
hiden add new user button in case the aggregator is only onboarded on pagoPA without the action to handle the users
<!--- Describe your changes in detail -->

#### Motivation and Context
The aggregator with role ADMIN_EA cannot add  new users on prod pagoPA.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested with mocked data in local enviroment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.