### PR TITLE
[SELC-5997] cetralized method to render the role for admin EA

### DIFF
--- a/src/model/ProductRole.ts
+++ b/src/model/ProductRole.ts
@@ -67,18 +67,21 @@ const productRolesGroupByProductRole = (
     return acc;
   }, {});
 
+const normalizedProductRole = (productRole: string) =>
+  productRole === 'ADMIN' || productRole === 'ADMIN_EA' ? 'admin' : productRole;
+
 export const transcodeProductRole2Title = (
   productRole: string,
   productRolesList: ProductRolesLists
 ) =>
-  productRolesList?.groupByProductRole[productRole]
-    ? productRolesList?.groupByProductRole[productRole].title
+  productRolesList?.groupByProductRole[normalizedProductRole(productRole)]
+    ? productRolesList?.groupByProductRole[normalizedProductRole(productRole)].title
     : productRole;
 
 export const transcodeProductRole2Description = (
   productRole: string,
   productRolesList: ProductRolesLists
 ) =>
-  productRolesList?.groupByProductRole[productRole]
-    ? productRolesList?.groupByProductRole[productRole].description
+  productRolesList?.groupByProductRole[normalizedProductRole(productRole)]
+    ? productRolesList?.groupByProductRole[normalizedProductRole(productRole)].description
     : productRole;

--- a/src/pages/dashboardUsers/components/UsersTableProduct/components/UserProductTableColumns.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableProduct/components/UserProductTableColumns.tsx
@@ -10,7 +10,7 @@ import i18n from '@pagopa/selfcare-common-frontend/lib/locale/locale-utils';
 import React, { CSSProperties, ReactNode } from 'react';
 import { PartyProductUser } from '../../../../../model/PartyUser';
 import { Product } from '../../../../../model/Product';
-import { ProductRolesLists } from '../../../../../model/ProductRole';
+import { ProductRolesLists, transcodeProductRole2Title } from '../../../../../model/ProductRole';
 
 export function buildColumnDefs(
   _product: Product,
@@ -248,9 +248,7 @@ function showRoles(
                   }
                   sx={{ outline: 'none', paddingLeft: 3 }}
                 >
-                  {productRolesLists?.groupByProductRole[r.role]
-                    ? productRolesLists?.groupByProductRole[r.role].title
-                    : r.role}
+                  {transcodeProductRole2Title(r.role, productRolesLists)}
                 </Typography>
               </Grid>
             )

--- a/src/pages/dashboardUsers/components/UsersTableProduct/components/UsersProductTable.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableProduct/components/UsersProductTable.tsx
@@ -12,7 +12,7 @@ import { useIsMobile } from '../../../../../hooks/useIsMobile';
 import { Party, UserStatus } from '../../../../../model/Party';
 import { PartyProductUser } from '../../../../../model/PartyUser';
 import { Product } from '../../../../../model/Product';
-import { ProductRolesByProductRoleType, ProductRolesLists } from '../../../../../model/ProductRole';
+import { ProductRolesLists, transcodeProductRole2Title } from '../../../../../model/ProductRole';
 import { DASHBOARD_USERS_ROUTES } from '../../../../../routes';
 import UserProductLoading from './UserProductLoading';
 import UserTableLoadMoreData from './UserProductLoadMoreData';
@@ -123,17 +123,6 @@ export default function UsersProductTable({
 
   const rowHeight = isMobile ? 250 : 64;
   const headerHeight = isMobile ? 10 : 56;
-
-  const getTitleByUserRole = (
-    userRole: UserRole,
-    groupByProductRole: ProductRolesByProductRoleType
-  ): string | undefined => {
-    const matchingRole = Object.values(groupByProductRole).find(
-      (roleDetails) => roleDetails.selcRole === userRole
-    );
-
-    return matchingRole?.title ?? '';
-  };
 
   return (
     <Box
@@ -248,7 +237,7 @@ export default function UsersProductTable({
                             whiteSpace: 'pre-wrap',
                           }}
                         >
-                          {getTitleByUserRole(userRole, productRolesLists.groupByProductRole)}
+                          {transcodeProductRole2Title(userRole, productRolesLists)}
                         </Typography>
                       </Grid>
                       {userSuspended && (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
used centralized method transcodeProductRole2Title to render the role title 
removed getTitleByUserRole 
fix for admin_ea not showing the label
<!--- Describe your changes in detail -->

#### Motivation and Context
The label for admin ea would not properly render and it was different from dektop to mobile.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by mocking dev enviroment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.