### PR TITLE
[SELC-6322] feat: avoid calling checkManager if no previous manager is avaible

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -60,12 +60,12 @@ export default {
         suspend: {
           title: 'Sospendi ruolo',
           message:
-            'Vuoi sospendere <1>{{user}}</1> dal ruolo di <3>{{userRole}}</3>?<4 />Se lo sospendi, non potrà più operare su <6>{{productTitle}}</6>. <8 />Puoi riabilitarlo in qualsiasi momento.',
+            'Vuoi sospendere <1>{{user}}</1> dal ruolo di <3>{{userRole}}</3>?<4 /> Se lo sospendi, non potrà più operare su <6>{{productTitle}}</6>. <8 />Puoi riabilitarlo in qualsiasi momento.',
         },
         reactivate: {
           title: 'Riabilita ruolo',
           message:
-            'Vuoi riabilitare <1>{{user}}</1> nel ruolo di <3>{{userRole}}</3>?<4 />Se lo riabiliti, potrà operare di nuovo su <6>{{productTitle}}</6>.<8 /> Puoi sospenderlo di nuovo in qualsiasi momento.',
+            'Vuoi riabilitare <1>{{user}}</1> nel ruolo di <3>{{userRole}}</3>?<4 /> Se lo riabiliti, potrà operare di nuovo su <6>{{productTitle}}</6>.<8 /> Puoi sospenderlo di nuovo in qualsiasi momento.',
         },
         confirmButton: 'Conferma',
         closeButton: 'Annulla',
@@ -115,14 +115,14 @@ export default {
         suspend: {
           title: 'Sospendi ruolo',
           messageWithOneRole:
-            'Vuoi sospendere <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 />Se lo sospendi, non potrà più operare su <6>{{productTitle}}</6>. <8 />Puoi riabilitarlo in qualsiasi momento.',
+            'Vuoi sospendere <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 /> Se lo sospendi, non potrà più operare su <6>{{productTitle}}</6>. <8 />Puoi riabilitarlo in qualsiasi momento.',
           messageWithMultipleRoles:
-            'Vuoi sospendere <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 />Puoi riabilitarlo in qualsiasi momento.',
+            'Vuoi sospendere <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 /> Puoi riabilitarlo in qualsiasi momento.',
         },
         reactivate: {
           title: 'Riabilita ruolo',
           messageWithOneRole:
-            'Vuoi riabilitare <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 />Se lo riabiliti, potrà operare di nuovo su <6>{{productTitle}}</6>.<8 /> Puoi sospenderlo di nuovo in qualsiasi momento.',
+            'Vuoi riabilitare <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 /> Se lo riabiliti, potrà operare di nuovo su <6>{{productTitle}}</6>.<8 /> Puoi sospenderlo di nuovo in qualsiasi momento.',
           messageWithMultipleRoles:
             'Vuoi riabilitare <1>{{user}}</1> dal ruolo di <3>{{productRole}}</3>?<4 />Puoi sospenderlo di nuovo in qualsiasi momento.',
         },

--- a/src/pages/dashboardUserEdit/components/AddLegalRepresentativeForm.tsx
+++ b/src/pages/dashboardUserEdit/components/AddLegalRepresentativeForm.tsx
@@ -61,40 +61,45 @@ export default function AddLegalRepresentativeForm({
 }: Readonly<LegalRepresentativeProps>) {
   const [isChangedManager, setIsChangedManager] = useState(false);
   const [dynamicDocLink, setDynamicDocLink] = useState<string>('');
-
   const [previousLegalRepresentative, setPreviousLegalRepresentative] =
-    useState<ProductUserResource>();
+    useState<ProductUserResource | null>();
+
   const requestId = uniqueId();
   const { t } = useTranslation();
   const setLoadingCheckManager = useLoading(LOADING_TASK_CHECK_MANAGER);
   const setLoadingGetLegalRepresentative = useLoading(LOADING_TASK_GET_LEGAL_REPRESENTATIVE);
   const addError = useErrorDispatcher();
 
+  const findNewestManager = (managers: Array<ProductUserResource>): ProductUserResource | null => {
+    if (!managers || managers.length === 0) {
+      return null;
+    }
+
+    return managers.reduce((newest, current) => {
+      if (!newest.createdAt || !current.createdAt) {
+        return newest;
+      }
+
+      return new Date(current.createdAt) > new Date(newest.createdAt) ? current : newest;
+    }, managers[0]);
+  };
+
+  const setFormValues = async (formik: any, manager: ProductUserResource | null) => {
+    await formik.setValues({
+      name: manager?.name ?? '',
+      surname: manager?.surname ?? '',
+      taxCode: manager?.fiscalCode ?? '',
+      email: manager?.email ?? '',
+      role: RoleEnum.MANAGER,
+    });
+  };
+
   useEffect(() => {
     setLoadingGetLegalRepresentative(true);
     getLegalRepresentativeService(party, productId, RoleEnum.MANAGER)
       .then(async (r) => {
-        const newestManager = r.reduce(
-          (newest: ProductUserResource, current: ProductUserResource) => {
-            if (!newest) {
-              return current;
-            }
-            if (!newest.createdAt || !current.createdAt) {
-              return newest;
-            }
-            return new Date(current.createdAt).getTime() > new Date(newest.createdAt).getTime()
-              ? current
-              : newest;
-          }
-        );
-
-        await formik.setValues({
-          name: newestManager.name ?? '',
-          surname: newestManager.surname ?? '',
-          taxCode: newestManager.fiscalCode ?? '',
-          email: newestManager.email ?? '',
-          role: RoleEnum.MANAGER,
-        });
+        const newestManager = findNewestManager(r);
+        await setFormValues(formik, newestManager);
         setPreviousLegalRepresentative(newestManager);
       })
       .catch((error) => {
@@ -180,48 +185,55 @@ export default function AddLegalRepresentativeForm({
     role: RoleEnum.MANAGER,
   };
 
+  const checkManager = async (user: AsyncOnboardingUserData) => {
+    setLoadingCheckManager(true);
+    checkManagerService({
+      institutionType: party.institutionType as any,
+      origin: party?.origin,
+      originId: party?.originId,
+      productId,
+      subunitCode: party?.subunitCode,
+      taxCode: party.vatNumber,
+      users: [{ ...user, role: RoleEnum.MANAGER as RoleEnum }],
+    })
+      .then(async (data) => {
+        if (data) {
+          setIsChangedManager(!data.result);
+          if (!data.result) {
+            trackEvent('CHANGE_LEGAL_REPRESENTATIVE', {
+              request_id: requestId,
+              party_id: party.partyId,
+              product_id: productId,
+              from: 'dashboard',
+            });
+          }
+          if (data.result) {
+            await validateUser(user);
+          }
+        }
+      })
+      .catch(async (error) => {
+        await validateUser(user);
+        addError({
+          id: `VALIDATE_USER_ERROR`,
+          blocking: false,
+          error,
+          techDescription: `Something gone wrong whilev calling check-manager`,
+          toNotify: true,
+        });
+      })
+      .finally(() => setLoadingCheckManager(false));
+  };
+
   const formik = useFormik<AsyncOnboardingUserData>({
     initialValues: initialFormData,
     validate,
-    onSubmit: (user) => {
-      setLoadingCheckManager(true);
-      checkManagerService({
-        institutionType: party.institutionType as any,
-        origin: party?.origin,
-        originId: party?.originId,
-        productId,
-        subunitCode: party?.subunitCode,
-        taxCode: party.vatNumber,
-        users: [{ ...user, role: RoleEnum.MANAGER as RoleEnum }],
-      })
-        .then((data) => {
-          if (data) {
-
-            setIsChangedManager(!data.result);
-            if (!data.result) {
-              trackEvent('CHANGE_LEGAL_REPRESENTATIVE', {
-                request_id: requestId,
-                party_id: party.partyId,
-                product_id: productId,
-                from: 'dashboard',
-              });
-            }
-            if (data.result) {
-              validateUser(user);
-            }
-          }
-        })
-        .catch((error) => {
-          validateUser(user);
-          addError({
-            id: `VALIDATE_USER_ERROR`,
-            blocking: false,
-            error,
-            techDescription: `Something gone wrong whilev calling check-manager`,
-            toNotify: true,
-          });
-        })
-        .finally(() => setLoadingCheckManager(false));
+    onSubmit: async (user) => {
+      if (previousLegalRepresentative) {
+        await checkManager(user);
+      } else {
+        await validateUser(user);
+      }
     },
   });
 
@@ -241,7 +253,7 @@ export default function AddLegalRepresentativeForm({
     return '';
   };
 
-  const validateUser = (user: AsyncOnboardingUserData) => {
+  const validateUser = async (user: AsyncOnboardingUserData) => {
     validateLegalRepresentative({
       name: user.name,
       surname: user.surname,
@@ -364,9 +376,9 @@ export default function AddLegalRepresentativeForm({
     <Grid>
       <ConfirmChangeLRModal
         open={isChangedManager}
-        onConfirm={() => {
+        onConfirm={async () => {
           setIsChangedManager(false);
-          validateUser(formik.values);
+          await validateUser(formik.values);
         }}
         onClose={() => setIsChangedManager(false)}
         managerFullName={`${previousLegalRepresentative?.name} ${previousLegalRepresentative?.surname}`}
@@ -382,7 +394,6 @@ export default function AddLegalRepresentativeForm({
               marginBottom: 5,
             }}
           >
-
             <Grid item mb={3}>
               <Grid item xs={12}>
                 <TitleBox

--- a/src/pages/dashboardUserEdit/components/AddLegalRepresentativeForm.tsx
+++ b/src/pages/dashboardUserEdit/components/AddLegalRepresentativeForm.tsx
@@ -80,7 +80,7 @@ export default function AddLegalRepresentativeForm({
         return newest;
       }
 
-      return new Date(current.createdAt) > new Date(newest.createdAt) ? current : newest;
+      return current.createdAt.getTime() > newest.createdAt.getTime() ? current : newest;
     }, managers[0]);
   };
 
@@ -206,8 +206,7 @@ export default function AddLegalRepresentativeForm({
               product_id: productId,
               from: 'dashboard',
             });
-          }
-          if (data.result) {
+          } else {
             await validateUser(user);
           }
         }
@@ -218,7 +217,7 @@ export default function AddLegalRepresentativeForm({
           id: `VALIDATE_USER_ERROR`,
           blocking: false,
           error,
-          techDescription: `Something gone wrong whilev calling check-manager`,
+          techDescription: `Something gone wrong while calling check-manager`,
           toNotify: true,
         });
       })


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
call check manager only when previous manager is avaible
improve code for readability 
add some space in copy of modal
<!--- Describe your changes in detail -->

#### Motivation and Context
When fetching the previous manager data returns an empty list, we can skip the check manager API call since there's no previous manager to compare against. This prevents unnecessary API calls
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.