### PR TITLE
[SELC-7247] feat: added hook useFocus to handle focus for accessibility in UserPage

### DIFF
--- a/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
+++ b/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
@@ -7,9 +7,10 @@ import { useUnloadEventOnExit } from '@pagopa/selfcare-common-frontend/lib/hooks
 import { trackEvent } from '@pagopa/selfcare-common-frontend/lib/services/analyticsService';
 import { Actions } from '@pagopa/selfcare-common-frontend/lib/utils/constants';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/lib/utils/routes-utils';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { useFocus } from '@pagopa/selfcare-common-frontend/lib/hooks/useFocus';
 import { useIsMobile } from '../../../hooks/useIsMobile';
 import { Party } from '../../../model/Party';
 import { Product, ProductsMap } from '../../../model/Product';
@@ -74,6 +75,10 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
     Object.fromEntries(selectedProducts.map((p) => [[p.id], { loading: true, noData: false }]));
   const [productsFetchStatus, setProductsFetchStatus] =
     useState<Record<string, { loading: boolean; noData: boolean }>>(initProductFetchStatus);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useFocus(buttonRef, []);
 
   useEffect(() => {
     setFilters(emptyFilters);
@@ -168,6 +173,8 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
                 variant="contained"
                 sx={{ height: '48px', width: '163px' }}
                 onClick={() => onExit(() => history.push(addUserUrl))}
+                ref={buttonRef}
+                tabIndex={0}
                 disabled={!canAddUser}
               >
                 {t('usersTable.addButton')}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- add hook useFocus in UserPage from selfcare-common-frontend

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Prevent focus from shifting to empty elements after user removal

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.