### PR TITLE
[SELC-7492] feat: remove unused user search and manager check services from onboarding API

### DIFF
--- a/src/api/OnboardingApiClient.ts
+++ b/src/api/OnboardingApiClient.ts
@@ -5,11 +5,9 @@ import {
 } from '@pagopa/selfcare-common-frontend/lib/utils/api-utils';
 import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import { ENV } from '../utils/env';
-import { CheckManagerDto } from './generated/onboarding/CheckManagerDto';
 import { createClient, WithDefaultsT } from './generated/onboarding/client';
 import { OnboardingUserDto } from './generated/onboarding/OnboardingUserDto';
 import { UserDataValidationDto } from './generated/onboarding/UserDataValidationDto';
-import { UserTaxCodeDto } from './generated/onboarding/UserTaxCodeDto';
 
 const withBearerAndInstitutionId: WithDefaultsT<'bearerAuth'> =
   (wrappedOperation) => (params: any) => {
@@ -41,16 +39,6 @@ const onRedirectToLogin = () =>
   );
 
 export const OnboardingApi = {
-  searchUserApi: async (user: UserTaxCodeDto): Promise<any> => {
-    const result = await apiClient.searchUserId({ body: user });
-    return extractResponse(result, 200, onRedirectToLogin);
-  },
-
-  checkManagerApi: async (user: CheckManagerDto): Promise<any> => {
-    const result = await apiClient.checkManager({ body: user });
-    return extractResponse(result, 200, onRedirectToLogin);
-  },
-
   validateLegalRepresentative: async (user: UserDataValidationDto): Promise<any> => {
     const result = await apiClient.validateUsingPOST({
       body: {

--- a/src/services/__mocks__/usersService.ts
+++ b/src/services/__mocks__/usersService.ts
@@ -11,10 +11,8 @@ import { mockedProductUserResource } from '../../api/__mocks__/DashboardApiClien
 import { CheckUserResponse } from '../../api/generated/b4f-dashboard/CheckUserResponse';
 import { ProductUserResource } from '../../api/generated/b4f-dashboard/ProductUserResource';
 import { UserCountResource } from '../../api/generated/b4f-dashboard/UserCountResource';
-import { CheckManagerDto } from '../../api/generated/onboarding/CheckManagerDto';
 import { OnboardingUserDto } from '../../api/generated/onboarding/OnboardingUserDto';
 import { UserDataValidationDto } from '../../api/generated/onboarding/UserDataValidationDto';
-import { UserTaxCodeDto } from '../../api/generated/onboarding/UserTaxCodeDto';
 import { Party, UserRole, UserStatus } from '../../model/Party';
 import { PartyGroup, PartyGroupStatus } from '../../model/PartyGroup';
 import {
@@ -1349,14 +1347,6 @@ export const fetchUserGroups = (
   );
   return Promise.resolve(userGroups);
 };
-
-export const searchUserMocked = (_user: UserTaxCodeDto): Promise<any> =>
-  Promise.resolve({
-    id: '121312312',
-  });
-
-export const checkManagerMocked = (_user: CheckManagerDto): Promise<any> =>
-  Promise.resolve({ result: false });
 
 export const validateLegalRepresentativeMocked = (_user: UserDataValidationDto): Promise<void> =>
   new Promise((resolve) => resolve());

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -1,32 +1,10 @@
-import { CheckManagerDto } from '../api/generated/onboarding/CheckManagerDto';
 import { OnboardingUserDto } from '../api/generated/onboarding/OnboardingUserDto';
 import { UserDataValidationDto } from '../api/generated/onboarding/UserDataValidationDto';
-import { UserTaxCodeDto } from '../api/generated/onboarding/UserTaxCodeDto';
 import { OnboardingApi } from '../api/OnboardingApiClient';
 import {
-  checkManagerMocked,
   onboardingPostUserMocked,
-  searchUserMocked,
   validateLegalRepresentativeMocked,
 } from './__mocks__/usersService';
-
-export const searchUserService = (userTaxCode: UserTaxCodeDto): Promise<any> => {
-  /* istanbul ignore if */
-  if (process.env.REACT_APP_API_MOCK_PARTY_USERS === 'true') {
-    return searchUserMocked(userTaxCode);
-  } else {
-    return OnboardingApi.searchUserApi(userTaxCode);
-  }
-};
-
-export const checkManagerService = (user: CheckManagerDto): Promise<any> => {
-  /* istanbul ignore if */
-  if (process.env.REACT_APP_API_MOCK_PARTY_USERS === 'true') {
-    return checkManagerMocked(user);
-  } else {
-    return OnboardingApi.checkManagerApi(user);
-  }
-};
 
 export const validateLegalRepresentative = (user: UserDataValidationDto): Promise<any> => {
   /* istanbul ignore if */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
removed user search and manager check services
removed mocked data
<!--- Describe your changes in detail -->

#### Motivation and Context
We have integrated the GET api to retrieve the previous LR data. 
That api can also be used to move the checkManager logic in the FE by comparing the previous LR fiscal code with the current one.
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.