### PR TITLE
[SELC-8427] feat: add state filter to users table

### DIFF
--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -25,6 +25,7 @@ export default {
     },
     filterRole: {
       placeholder: 'Alle Funktionen',
+      statePlaceholder: 'Status',
       admin: {
         title: 'Administrator',
         description: 'Hat alle Berechtigungen und verwaltet die Benutzer',

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -25,6 +25,7 @@ export default {
     },
     filterRole: {
       placeholder: 'All roles',
+      statePlaceholder: 'Status',
       admin: {
         title: 'Administrator',
         description: 'You have all permissions and manage the users',

--- a/src/locale/fr.ts
+++ b/src/locale/fr.ts
@@ -25,6 +25,7 @@ export default {
     },
     filterRole: {
       placeholder: 'Tous les rôles',
+      statePlaceholder: 'Statut',
       admin: {
         title: 'Administrateur',
         description: 'Il a toutes les autorisations nécessaires et gère les utilisateurs',

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -33,6 +33,7 @@ export default {
     },
     filterRole: {
       placeholder: 'Tutti i ruoli',
+      statePlaceholder: 'Stato',
       admin: {
         title: 'Amministratore',
         description: 'Ha tutti i permessi e gestisce gli utenti',

--- a/src/locale/sl.ts
+++ b/src/locale/sl.ts
@@ -25,6 +25,7 @@ export default {
     },
     filterRole: {
       placeholder: 'Vse vloge',
+      statePlaceholder: 'Stanje',
       admin: {
         title: 'Upravitelj',
         description: 'Ima vsa dovoljenja in upravlja uporabnike',

--- a/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
+++ b/src/pages/dashboardUsers/UsersPage/UsersPage.tsx
@@ -40,6 +40,7 @@ const emptyFilters: UsersTableFiltersConfig = {
   productIds: [],
   productRoles: [],
   partyRoles: [],
+  states: [],
 };
 
 // eslint-disable-next-line complexity, sonarjs/cognitive-complexity
@@ -68,6 +69,7 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
   const [disableRemoveFiltersButton, setDisableRemoveFiltersButton] = useState<boolean>(true);
   const [copied, setCopied] = useState(false);
   const [selectedPartyRoles, setSelectedPartyRoles] = useState<Array<PartyRole>>([]);
+  const [selectedStates, setSelectedStates] = useState<Array<string>>([]);
 
   const { t } = useTranslation();
   const history = useHistory();
@@ -282,6 +284,8 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
           setDisableRemoveFiltersButton={setDisableRemoveFiltersButton}
           selectedPartyRoles={selectedPartyRoles}
           setSelectedPartyRoles={setSelectedPartyRoles}
+          selectedStates={selectedStates}
+          setSelectedStates={setSelectedStates}
         />
         {isMobile ? (
           <Grid item mt={isMobile ? 3 : 0}>
@@ -313,6 +317,8 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
             setDisableRemoveFiltersButton={setDisableRemoveFiltersButton}
             selectedPartyRoles={selectedPartyRoles}
             setSelectedPartyRoles={setSelectedPartyRoles}
+            selectedStates={selectedStates}
+            setSelectedStates={setSelectedStates}
           />
         )}
         {moreThanOneActiveProduct && (
@@ -379,6 +385,7 @@ function UsersPage({ party, activeProducts, productsMap, productsRolesMap }: Rea
                   setSearchByName('');
                   setDisableRemoveFiltersButton(false);
                   setSelectedPartyRoles([]);
+                  setSelectedStates([]);
                 }}
               />
             )}

--- a/src/pages/dashboardUsers/components/MobileFilter.tsx
+++ b/src/pages/dashboardUsers/components/MobileFilter.tsx
@@ -102,6 +102,8 @@ type Props = {
   setDisableRemoveFiltersButton: React.Dispatch<React.SetStateAction<boolean>>;
   selectedPartyRoles: Array<PartyRole>;
   setSelectedPartyRoles: React.Dispatch<React.SetStateAction<Array<PartyRole>>>;
+  selectedStates: Array<string>;
+  setSelectedStates: React.Dispatch<React.SetStateAction<Array<string>>>;
 };
 
 export default function MobileFilter({
@@ -119,6 +121,8 @@ export default function MobileFilter({
   setDisableRemoveFiltersButton,
   selectedPartyRoles,
   setSelectedPartyRoles,
+  selectedStates,
+  setSelectedStates,
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const isMobile = useIsMobile('md');
@@ -177,6 +181,8 @@ export default function MobileFilter({
             setDisableRemoveFiltersButton={setDisableRemoveFiltersButton}
             selectedPartyRoles={selectedPartyRoles}
             setSelectedPartyRoles={setSelectedPartyRoles}
+            selectedStates={selectedStates}
+            setSelectedStates={setSelectedStates}
           />
         </Grid>
       </DialogContent>

--- a/src/pages/dashboardUsers/components/UsersTableActions/UsersTableFilters.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableActions/UsersTableFilters.tsx
@@ -10,6 +10,8 @@ export type UsersTableFiltersConfig = {
   productRoles: Array<ProductRole>;
   /** The party roles selected as filter */
   partyRoles: Array<string>;
+  /** The states selected as filter */
+  states: Array<string>;
 };
 interface UsersSearchFilterProps {
   products: Array<Product>;
@@ -27,6 +29,8 @@ interface UsersSearchFilterProps {
   setDisableRemoveFiltersButton: React.Dispatch<React.SetStateAction<boolean>>;
   selectedPartyRoles: Array<PartyRole>;
   setSelectedPartyRoles: React.Dispatch<React.SetStateAction<Array<PartyRole>>>;
+  selectedStates: Array<string>;
+  setSelectedStates: React.Dispatch<React.SetStateAction<Array<string>>>;
 }
 
 export default function UsersTableFilters({
@@ -43,6 +47,8 @@ export default function UsersTableFilters({
   setDisableRemoveFiltersButton,
   selectedPartyRoles,
   setSelectedPartyRoles,
+  selectedStates,
+  setSelectedStates,
 }: Readonly<UsersSearchFilterProps>) {
   const productRolesList: Array<ProductRole> = Object.values(productsRolesMap).flatMap(
     (p) => p.list
@@ -64,6 +70,8 @@ export default function UsersTableFilters({
       setDisableRemoveFiltersButton={setDisableRemoveFiltersButton}
       selectedPartyRoles={selectedPartyRoles}
       setSelectedPartyRoles={setSelectedPartyRoles}
+      selectedStates={selectedStates}
+      setSelectedStates={setSelectedStates}
     />
   );
 }

--- a/src/pages/dashboardUsers/components/UsersTableActions/UsersTableRolesFilter.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableActions/UsersTableRolesFilter.tsx
@@ -1,4 +1,12 @@
-import { Button, Grid, ListItemText, MenuItem, SelectChangeEvent, TextField } from '@mui/material';
+import {
+  Button,
+  Grid,
+  ListItemText,
+  MenuItem,
+  SelectChangeEvent,
+  TextField,
+  Typography,
+} from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import { ButtonNaked } from '@pagopa/mui-italia';
@@ -160,6 +168,21 @@ export default function UsersTableRolesFilter({
   const isFilterButtonDisabled = isPagoPa
     ? selectedPartyRoles.length === 0 && selectedStates.length === 0 && searchByName.length < 3
     : isEqual(productRolesSelected, nextProductRolesFilter) && searchByName.length < 3;
+  const renderTruncatedValue = (text: string) => (
+    <Typography
+      component="span"
+      sx={{
+        display: 'block',
+        width: '100%',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+    >
+      {text}
+    </Typography>
+  );
+
   return (
     <Grid
       container
@@ -167,10 +190,11 @@ export default function UsersTableRolesFilter({
       spacing={isMobile ? 3 : 2}
       display="flex"
       mt={isMobile ? 0 : 5}
+      flexWrap={isMobile ? 'wrap' : 'nowrap'}
       flexDirection={isMobile ? 'column' : 'row'}
     >
       {LiveRegion}
-      <Grid item xs={12} md={isPagoPa ? 4 : 5} width="100%">
+      <Grid item xs={12} md={true} sx={{ minWidth: 0, flexGrow: 1, flexShrink: 1 }}>
         <TextField
           fullWidth
           size="small"
@@ -180,7 +204,7 @@ export default function UsersTableRolesFilter({
           onChange={(e) => setSearchByName(e.target.value)}
         />
       </Grid>
-      <Grid item xs={12} md={isPagoPa ? 3 : 4.5}>
+      <Grid item xs={12} md={true} sx={{ minWidth: 0, flexGrow: 1, flexShrink: 1 }}>
         {isPagoPa ? (
           <CustomSelect
             fullWidth
@@ -190,9 +214,11 @@ export default function UsersTableRolesFilter({
             onChange={handleRolesChange}
             input={<OutlinedInput />}
             renderValue={(selected) =>
-              (selected as Array<PartyRole>).length === 0
-                ? t('usersTable.filterRole.placeholder')
-                : (selected as Array<PartyRole>).join(', ')
+              renderTruncatedValue(
+                (selected as Array<PartyRole>).length === 0
+                  ? t('usersTable.filterRole.placeholder')
+                  : (selected as Array<PartyRole>).join(', ')
+              )
             }
             displayEmpty
           >
@@ -214,8 +240,8 @@ export default function UsersTableRolesFilter({
         )}
       </Grid>
 
-      {true && (
-        <Grid item xs={12} md={2.5}>
+      {isPagoPa && (
+        <Grid item xs={12} md={true} sx={{ minWidth: 0, flexGrow: 1, flexShrink: 1 }}>
           <CustomSelect
             fullWidth
             size="small"
@@ -224,11 +250,13 @@ export default function UsersTableRolesFilter({
             onChange={handleStatesChange}
             input={<OutlinedInput />}
             renderValue={(selected) =>
-              (selected as Array<string>).length === 0
-                ? t('usersTable.filterRole.statePlaceholder')
-                : (selected as Array<string>)
-                    .map((s) => t(stateOptions.find((o) => o.value === s)?.labelKey ?? ''))
-                    .join(', ')
+              renderTruncatedValue(
+                (selected as Array<string>).length === 0
+                  ? t('usersTable.filterRole.statePlaceholder')
+                  : (selected as Array<string>)
+                      .map((s) => t(stateOptions.find((o) => o.value === s)?.labelKey ?? ''))
+                      .join(', ')
+              )
             }
             displayEmpty
           >
@@ -242,7 +270,7 @@ export default function UsersTableRolesFilter({
         </Grid>
       )}
 
-      <Grid item xs={12} md={1}>
+      <Grid item xs={12} md="auto" sx={{ flexShrink: 0 }}>
         <Button
           disabled={isFilterButtonDisabled}
           color="primary"
@@ -250,17 +278,19 @@ export default function UsersTableRolesFilter({
           type="submit"
           size="small"
           fullWidth
+          sx={{ whiteSpace: 'nowrap' }}
           onClick={handleSubmit}
         >
           {t('usersTable.filterRole.addFilters')}
         </Button>
       </Grid>
-      <Grid item xs={12} md={1.5} display="flex" alignItems="center">
+      <Grid item xs={12} md="auto" display="flex" alignItems="center" sx={{ flexShrink: 0 }}>
         <ButtonNaked
           disabled={nextProductRolesFilter.length === 0 && disableRemoveFiltersButton}
           color="primary"
           fullWidth
           size="small"
+          sx={{ whiteSpace: 'nowrap' }}
           onClick={handleResetFilters}
         >
           {t('usersTable.filterRole.deleteFilters')}

--- a/src/pages/dashboardUsers/components/UsersTableActions/UsersTableRolesFilter.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableActions/UsersTableRolesFilter.tsx
@@ -35,6 +35,8 @@ type Props = {
   setDisableRemoveFiltersButton: React.Dispatch<React.SetStateAction<boolean>>;
   selectedPartyRoles: Array<PartyRole>;
   setSelectedPartyRoles: React.Dispatch<React.SetStateAction<Array<PartyRole>>>;
+  selectedStates: Array<string>;
+  setSelectedStates: React.Dispatch<React.SetStateAction<Array<string>>>;
 };
 
 export default function UsersTableRolesFilter({
@@ -49,6 +51,8 @@ export default function UsersTableRolesFilter({
   setDisableRemoveFiltersButton,
   selectedPartyRoles,
   setSelectedPartyRoles,
+  selectedStates,
+  setSelectedStates,
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const isMobile = useIsMobile('md');
@@ -115,6 +119,7 @@ export default function UsersTableRolesFilter({
         ...filters,
         productIds: nextProductRolesFilter.map((f) => f.productId),
         partyRoles: selectedPartyRoles,
+        states: selectedStates,
       });
     } else {
       onFiltersChange({
@@ -128,9 +133,10 @@ export default function UsersTableRolesFilter({
   };
 
   const handleResetFilters = () => {
-    onFiltersChange({ ...filters, productIds: [], productRoles: [], partyRoles: [] });
+    onFiltersChange({ ...filters, productIds: [], productRoles: [], partyRoles: [], states: [] });
     setSearchByName('');
     setSelectedPartyRoles([]);
+    setSelectedStates([]);
     setDisableRemoveFiltersButton(true);
     announce(t('accessibility.removeFilters'));
   };
@@ -140,25 +146,20 @@ export default function UsersTableRolesFilter({
     setSelectedPartyRoles(value);
   };
 
-  const isFilterButtonDisabled = isPagoPa
-    ? selectedPartyRoles.length === 0 && searchByName.length < 3
-    : isEqual(productRolesSelected, nextProductRolesFilter) && searchByName.length < 3;
-  /*
-TODO for status filter
-  const PARTY_STATUS_OPTIONS: Array<PartyStatus> = [
-    'ACTIVE',
-    'SUSPENDED',
-    'PENDING',
-    'TOBEVALIDATED',
-    'REJECTED',
+  const stateOptions: Array<{ value: string; labelKey: string }> = [
+    { value: 'ACTIVE', labelKey: 'usersTable.usersProductTableColumns.rows.activeChip' },
+    { value: 'SUSPENDED', labelKey: 'usersTable.usersProductTableColumns.rows.suspendedChip' },
+    { value: 'DELETED', labelKey: 'usersTable.usersProductTableColumns.rows.removedChip' },
   ];
 
-  const [selectedStatus, setSelectedStatus] = useState<PartyStatus | ''>('');
-
-  const handleStatusChange = (event: SelectChangeEvent<PartyStatus | ''>) => {
-    setSelectedStatus(event.target.value as PartyStatus | '');
+  const handleStatesChange = (event: SelectChangeEvent<unknown>) => {
+    const value = event.target.value as Array<string>;
+    setSelectedStates(value);
   };
-*/
+
+  const isFilterButtonDisabled = isPagoPa
+    ? selectedPartyRoles.length === 0 && selectedStates.length === 0 && searchByName.length < 3
+    : isEqual(productRolesSelected, nextProductRolesFilter) && searchByName.length < 3;
   return (
     <Grid
       container
@@ -169,7 +170,7 @@ TODO for status filter
       flexDirection={isMobile ? 'column' : 'row'}
     >
       {LiveRegion}
-      <Grid item xs={12} md={5} width="100%">
+      <Grid item xs={12} md={isPagoPa ? 4 : 5} width="100%">
         <TextField
           fullWidth
           size="small"
@@ -179,7 +180,7 @@ TODO for status filter
           onChange={(e) => setSearchByName(e.target.value)}
         />
       </Grid>
-      <Grid item xs={12} md={4.5}>
+      <Grid item xs={12} md={isPagoPa ? 3 : 4.5}>
         {isPagoPa ? (
           <CustomSelect
             fullWidth
@@ -212,6 +213,34 @@ TODO for status filter
           />
         )}
       </Grid>
+
+      {true && (
+        <Grid item xs={12} md={2.5}>
+          <CustomSelect
+            fullWidth
+            size="small"
+            multiple
+            value={selectedStates}
+            onChange={handleStatesChange}
+            input={<OutlinedInput />}
+            renderValue={(selected) =>
+              (selected as Array<string>).length === 0
+                ? t('usersTable.filterRole.statePlaceholder')
+                : (selected as Array<string>)
+                    .map((s) => t(stateOptions.find((o) => o.value === s)?.labelKey ?? ''))
+                    .join(', ')
+            }
+            displayEmpty
+          >
+            {stateOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                <Checkbox checked={selectedStates.includes(option.value)} />
+                <ListItemText primary={t(option.labelKey)} />
+              </MenuItem>
+            ))}
+          </CustomSelect>
+        </Grid>
+      )}
 
       <Grid item xs={12} md={1}>
         <Button

--- a/src/pages/dashboardUsers/components/UsersTableActions/__tests__/UsersTableRolesFilter.test.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableActions/__tests__/UsersTableRolesFilter.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import UsersTableRolesFilter from '../UsersTableRolesFilter';
+import { UsersTableFiltersConfig } from '../UsersTableFilters';
+
+vi.mock('@pagopa/selfcare-common-frontend/lib/utils/storage', () => ({
+  isPagoPaUser: () => true,
+}));
+
+vi.mock('../../../../hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+const emptyFilters: UsersTableFiltersConfig = {
+  productIds: [],
+  productRoles: [],
+  partyRoles: [],
+  states: [],
+};
+
+// Stateful wrapper mirroring how UsersTableFilters/UsersPage manage state,
+// so real UI interactions (opening the select, clicking an option) update state.
+function Wrapper({ onFiltersChange }: { onFiltersChange: (f: UsersTableFiltersConfig) => void }) {
+  const [filters, setFilters] = useState<UsersTableFiltersConfig>(emptyFilters);
+  const [searchByName, setSearchByName] = useState('');
+  const [disableRemoveFiltersButton, setDisableRemoveFiltersButton] = useState(true);
+  const [selectedPartyRoles, setSelectedPartyRoles] = useState<Array<any>>([]);
+  const [selectedStates, setSelectedStates] = useState<Array<string>>([]);
+
+  return (
+    <UsersTableRolesFilter
+      productRolesList={[]}
+      productRolesSelected={[]}
+      filters={filters}
+      onFiltersChange={(f) => {
+        setFilters(f);
+        onFiltersChange(f);
+      }}
+      disableFilters={false}
+      showSelcRoleGrouped={false}
+      loading={false}
+      setOpenDialogMobile={vi.fn()}
+      searchByName={searchByName}
+      setSearchByName={setSearchByName}
+      disableRemoveFiltersButton={disableRemoveFiltersButton}
+      setDisableRemoveFiltersButton={setDisableRemoveFiltersButton}
+      selectedPartyRoles={selectedPartyRoles}
+      setSelectedPartyRoles={setSelectedPartyRoles}
+      selectedStates={selectedStates}
+      setSelectedStates={setSelectedStates}
+    />
+  );
+}
+
+const renderComponent = (onFiltersChange = vi.fn()) => {
+  render(<Wrapper onFiltersChange={onFiltersChange} />);
+  return { onFiltersChange };
+};
+
+test('renders the state filter select with placeholder', () => {
+  renderComponent();
+  expect(screen.getByText('Stato')).toBeInTheDocument();
+});
+
+test('selecting a state option enables filter button and submits states filter', () => {
+  const { onFiltersChange } = renderComponent();
+
+  const filterButton = screen.getByRole('button', { name: 'Filtra' });
+  expect(filterButton).toBeDisabled();
+
+  const stateSelect = screen.getByText('Stato');
+  fireEvent.mouseDown(stateSelect);
+
+  const activeOption = screen.getByText('Attivo');
+  fireEvent.click(activeOption);
+
+  expect(filterButton).toBeEnabled();
+  fireEvent.click(filterButton);
+
+  expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ states: ['ACTIVE'] }));
+});
+
+test('resetting filters clears selected states', () => {
+  const { onFiltersChange } = renderComponent();
+
+  const filterButton = screen.getByRole('button', { name: 'Filtra' });
+  const deleteFiltersButton = screen.getByText('Rimuovi filtri');
+
+  fireEvent.mouseDown(screen.getByText('Stato'));
+  fireEvent.click(screen.getByText('Attivo'));
+  fireEvent.click(filterButton);
+
+  expect(onFiltersChange).toHaveBeenLastCalledWith(expect.objectContaining({ states: ['ACTIVE'] }));
+
+  fireEvent.click(deleteFiltersButton);
+
+  expect(onFiltersChange).toHaveBeenLastCalledWith(expect.objectContaining({ states: [] }));
+});

--- a/src/pages/dashboardUsers/components/UsersTableProduct/UsersTableProduct.tsx
+++ b/src/pages/dashboardUsers/components/UsersTableProduct/UsersTableProduct.tsx
@@ -80,7 +80,7 @@ const UsersTableProduct = ({
         product,
         currentUser ?? ({ uid: 'NONE' } as User),
         productsMap,
-        undefined,
+        filterConfiguration.states.join(','),
         filterConfiguration.partyRoles.join(',')
       ).then((data) => {
         if (searchByName) {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add a new "state" filter option to the users page, allowing users to
filter the table by user state in addition to existing filters like
product roles and party roles. This includes:

- New `statePlaceholder` translation key across all supported locales
  (de, en, fr, it, sl)
- New `selectedStates` state and `setSelectedStates` setter in
  `UsersPage` component
- Propagation of `selectedStates`/`setSelectedStates` props to both
  desktop and mobile filter components
- Reset of selected states when filters are cleared
<!--- Describe your changes in detail -->

#### Motivation and Context
Allow filtering users by state  in backstage 
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.